### PR TITLE
adding dockerfile maven plugin and Dockerfile to accenture customer data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM openjdk:8
+ARG JAR_FILE
+
+USER 12:acn_group
+COPY --chown=12 ./target/${JAR_FILE} /src/share/customer-data.jar
+
+WORKDIR /src/share/
+
+ENTRYPOINT ["java","-Djava.security.egd=file:/dev/urandom","-jar","customer-data.jar"]

--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,7 @@
 
 	<properties>
 		<java.version>1.8</java.version>
+		<dockerfile-maven-version>1.4.13</dockerfile-maven-version>
 	</properties>
 
 	<dependencies>
@@ -42,6 +43,26 @@
 			<plugin>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-maven-plugin</artifactId>
+			</plugin>
+			<plugin>
+				<groupId>com.spotify</groupId>
+				<artifactId>dockerfile-maven-plugin</artifactId>
+				<version>${dockerfile-maven-version}</version>
+				<executions>
+					<execution>
+						<id>build</id>
+						<goals>
+							<goal>build</goal>
+						</goals>
+					</execution>
+				</executions>
+				<configuration>
+					<repository>tepetrol/acc-micro-svc-group</repository>
+					<tag>${project.version}</tag>
+					<buildArgs>
+						<JAR_FILE>${project.build.finalName}.jar</JAR_FILE>
+					</buildArgs>
+				</configuration>
 			</plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
Adding docker maven plugin and Dockerfile. Created a registry at  [here](https://hub.docker.com/repository/docker/tepetrol/acc-micro-svc-group). The command doesn't include the 'push' yet to the registry, as we need to make some maven dependencies clear first on each developers so we can push it to the registry. 